### PR TITLE
Refetch CSS bodies missing from the HAR

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,11 @@ export default [
       globals: {
         node: true,
         es6: true,
-        URL: "readonly"
+        URL: "readonly",
+        fetch: "readonly",
+        AbortController: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly"
       },
       parserOptions: {
         ecmaVersion: 'latest',

--- a/lib/harAnalyzer.js
+++ b/lib/harAnalyzer.js
@@ -20,7 +20,7 @@ export class HarAnalyzer {
         this.version = this.package.version;
     }
 
-    transform2SimplifiedData(harData, url) {
+    async transform2SimplifiedData(harData, url) {
         const data = {
             'url': url,
             'rules': this.config.rules,
@@ -37,12 +37,25 @@ export class HarAnalyzer {
 
         let reqIndex = 1;
 
+        // CSS resources whose response body is missing from the HAR (served from
+        // cache, 304 Not Modified, or recorded with an empty body). We refetch
+        // these below — otherwise the custom properties they define are absent
+        // from the linted CSS and every var() referencing them elsewhere is
+        // falsely reported as "Unknown custom property" (no-unknown-custom-properties).
+        const missingCssUrls = new Set();
+
         for (const entry of harData.entries) {
             const req = entry.request;
             const res = entry.response;
             const reqUrl = req.url;
 
+            const mimeType = (res && res.content && res.content.mimeType) || '';
+            const looksLikeCss = mimeType.includes('css') || /\.css(\?|#|$)/i.test(reqUrl);
+
             if (!res.content || !res.content.text || !res.content.mimeType || !res.content.size || res.content.size <= 0 || !res.status) {
+                if (looksLikeCss && /^https?:\/\//i.test(reqUrl)) {
+                    missingCssUrls.add(reqUrl);
+                }
                 continue;
             }
 
@@ -59,6 +72,46 @@ export class HarAnalyzer {
                 data['style-files'].push(obj);
             }
 
+            reqIndex++;
+        }
+
+        // Refetch the bodies of CSS files that were absent from the HAR, skipping
+        // any we already captured. Failures (network error, timeout, non-OK) are
+        // ignored so a single unreachable file never fails the whole CSS test.
+        const refetchUrls = [...missingCssUrls].filter(
+            (cssUrl) => !data['style-files'].some((o) => o.url === cssUrl)
+        );
+        const refetched = await Promise.all(
+            refetchUrls.map(async (cssUrl) => {
+                try {
+                    const controller = new AbortController();
+                    const timeout = setTimeout(() => controller.abort(), 10000);
+                    const response = await fetch(cssUrl, { signal: controller.signal });
+                    clearTimeout(timeout);
+                    if (!response.ok) {
+                        return null;
+                    }
+                    const text = await response.text();
+                    if (!text) {
+                        return null;
+                    }
+                    return { url: cssUrl, content: text };
+                } catch {
+                    return null;
+                }
+            })
+        );
+        for (const item of refetched) {
+            if (!item) {
+                continue;
+            }
+            const obj = {
+                'url': item.url,
+                'content': item.content,
+                'index': reqIndex
+            };
+            data['all-styles'].push(obj);
+            data['style-files'].push(obj);
             reqIndex++;
         }
 
@@ -229,7 +282,7 @@ export class HarAnalyzer {
             this.groups[group] = {};
         }
 
-        const analyzedData = this.transform2SimplifiedData(harData, url);
+        const analyzedData = await this.transform2SimplifiedData(harData, url);
         if (!('analyzedData' in this.groups[group])) {
             this.groups[group]['analyzedData'] = []
         }


### PR DESCRIPTION
## Problem

Test 27 (`TEST_LINT_CSS`) concatenates all CSS from the HAR and lints it with stylelint. The `no-unknown-custom-properties` rule resolves `var(--x)` only against custom-property definitions present in the linted CSS.

When a stylesheet that *defines* custom properties is served from cache, returns `304 Not Modified`, or is recorded with an empty body, its HAR entry has no `response.content.text`/`size` and is dropped in `harAnalyzer.js`. Every `var()` referencing those properties in the stylesheets that *were* captured is then falsely reported as **"Unknown custom property"** → `CSS, Disallow unknown custom properties (fel)`.

Surfaced as a false positive on https://tillvaxtverket.se: `filterable-list.css` / `dark-mode.css` consume `--lp-*` design tokens defined in `variables.css`; when the defining files come back bodyless, all those references look undefined.

## Fix

Detect bodyless CSS entries (by mime type or `.css` URL) and refetch their content over HTTP before linting. Refetches run in parallel with a 10s timeout each; failures (network error, timeout, non-OK, empty body) are ignored so a single unreachable file never fails the whole test.

## Verification

Built a HAR from the real tillvaxtverket.se CSS with the definition files served bodyless (`304` / size `0`) and ran the actual `HarAnalyzer`:

| | active `no-unknown-custom-properties` issues | CSS files linted |
|---|---|---|
| Before | 74 (false positives) | 1 |
| After | 0 | 49 (48 refetched) |

When every stylesheet has a body, output is unchanged.

## Known limitation

Custom properties defined purely at runtime via JS (`el.style.setProperty('--x', …)`) still can't be resolved by static linting — out of scope here.