### PR TITLE
Report unknown custom properties/media as warning, not error

### DIFF
--- a/configurations/standard.json
+++ b/configurations/standard.json
@@ -156,14 +156,14 @@
         "no-unknown-custom-media": [
             true,
             {
-                "severity": "error",
+                "severity": "warning",
                 "message": "Unknown custom media query \u201c%s\u201d"
             }
         ],
         "no-unknown-custom-properties": [
             true,
             {
-                "severity": "error",
+                "severity": "warning",
                 "message": "Unknown custom property \u201c%s\u201d"
             }
         ],

--- a/tools/update_stylelint.py
+++ b/tools/update_stylelint.py
@@ -43,6 +43,14 @@ def update_stylelint_rules():
                         break
 
         if 'no-unknown' in rule_name:
+            # Unknown custom properties/media reference values that are
+            # frequently defined where static analysis can't see them (set at
+            # runtime via JS, in inline style attributes, on a page that wasn't
+            # crawled, or built at compile time by PostCSS). A missing one
+            # degrades gracefully to the initial/inherited value rather than
+            # producing invalid CSS, so report it as a warning, not an error.
+            if rule_name in ('no-unknown-custom-properties', 'no-unknown-custom-media'):
+                rule_config["severity"] = "warning"
             rules[rule_name] = [rule_enable, rule_config]
         elif 'no-deprecated' in rule_name:
             rule_config["severity"] = "warning"


### PR DESCRIPTION
## What

Downgrade `no-unknown-custom-properties` and `no-unknown-custom-media` from `error` to `warning`.

## Why

Both rules assert a *negative* — that a referenced custom property / custom media query is defined **nowhere**. Unlike rules that detect genuinely malformed CSS (`property-no-unknown`, `color-no-invalid-hex`, …), this can't be verified by static analysis of the CSS captured from a single crawled page. Custom properties are legitimately defined in places the linter never sees:

- set at runtime via JS (`element.style.setProperty('--x', …)`) — common for theming / dark mode,
- set in inline `style="--x: …"` attributes,
- defined in a `:root`/section block on a page that wasn't the one crawled,
- (custom media) produced at build time by PostCSS and absent from delivered CSS.

A missing custom property also **degrades gracefully** — `var(--undefined)` with no fallback becomes invalid-at-computed-value-time and falls back to the initial/inherited value, rather than producing invalid CSS. That is warning-shaped, not error-shaped.

Real example that prompted this: https://tillvaxtverket.se references four `--lp-filterable-list__control--*` theming hooks it never defines. The page renders fine (the inputs just use default styling), but the finding was reported as `error` (`fel`) and pulled down the standards grade.

## Notes

- `configurations/standard.json` is generated, so the change is in `tools/update_stylelint.py`; the regenerated `standard.json` is included and is byte-identical to a fresh run against the pinned stylelint 17.12.0.
- All other `no-unknown-*` rules stay at `error`.